### PR TITLE
Enhancements

### DIFF
--- a/WorldTraderSim/src/WorldTraderSim/DataTypes/Node.py
+++ b/WorldTraderSim/src/WorldTraderSim/DataTypes/Node.py
@@ -29,6 +29,7 @@ class Node(object):
       self.PARENT = parent
       self.PARENT_ACTION = parent_action
       self.PATH_COST = path_cost
+      self.DEPTH = None
 
    def __eq__(self, other: Node) -> bool:
       return self.state_hash() == other.state_hash()
@@ -49,9 +50,14 @@ class Node(object):
       return self.STATE_HASH
 
    def depth(self):
+      if self.DEPTH:
+         return self.DEPTH
+      
       node_count = 1
       current_node = self.PARENT
       while current_node:
          node_count += 1
          current_node = current_node.PARENT
-      return node_count
+      self.DEPTH = node_count
+
+      return self.DEPTH

--- a/WorldTraderSim/src/WorldTraderSim/DataTypes/Node.py
+++ b/WorldTraderSim/src/WorldTraderSim/DataTypes/Node.py
@@ -16,6 +16,7 @@ class Node(object):
 
    ID: UUID
    STATE: Dict[str, Country]
+   STATE_HASH: str
    PARENT: Node
    PARENT_ACTION: Action
    PATH_COST: float
@@ -24,6 +25,7 @@ class Node(object):
       super().__init__()
       self.ID = uuid4()
       self.STATE = state
+      self.STATE_HASH = None
       self.PARENT = parent
       self.PARENT_ACTION = parent_action
       self.PATH_COST = path_cost
@@ -32,6 +34,9 @@ class Node(object):
       return self.state_hash() == other.state_hash()
 
    def state_hash(self) -> str:
+      if self.STATE_HASH:
+         return self.STATE_HASH
+      
       json_state = {}
       for name, country in self.STATE.items():
          json_state[name] = dict(country)
@@ -39,7 +44,9 @@ class Node(object):
       dhash = hashlib.md5()
       encoded = json.dumps(json_state, sort_keys=True).encode()
       dhash.update(encoded)
-      return dhash.hexdigest()
+
+      self.STATE_HASH = dhash.hexdigest()
+      return self.STATE_HASH
 
    def depth(self):
       node_count = 1

--- a/WorldTraderSim/src/WorldTraderSim/Evaluators/ScheduleEvaluator.py
+++ b/WorldTraderSim/src/WorldTraderSim/Evaluators/ScheduleEvaluator.py
@@ -1,4 +1,5 @@
 # Standard Libraries
+from configparser import ConfigParser
 import logging
 import math
 from typing import Callable, Dict
@@ -7,53 +8,116 @@ from typing import Callable, Dict
 from DataTypes import Country, Schedule
 
 # Numeric Constants
-# TODO - allow config at runtime
-SCHEDULE_FAILED_IMPACT=-0.25
-SCHEDULE_LENGTH_IMPACT=0.9
+SCHEDULE_FAILED_IMPACT=-0.35
+SCHEDULE_LENGTH_IMPACT=0.999
+LOGISTIC_FUNCTION_MIDPOINT=0
+LOGISTIC_FUNCTION_GROWTH=1
 
 class ScheduleEvaluator:
-  def __init__(self, initial_state: Dict[str, Country], state_quality_fn: Callable[[Country], float]) -> None:
+  def __init__(self, initial_state: Dict[str, Country], state_quality_fn: Callable[[Country], float], self_country_name: str) -> None:
     self.initial_state = initial_state
     self.state_quality_fn = state_quality_fn
+    self.self_country_name = self_country_name
+    self.initial_quality_lookup = {}
+    self.schedule_failed_impact = SCHEDULE_FAILED_IMPACT
+    self.schedule_length_impact = SCHEDULE_LENGTH_IMPACT
+    self.logistic_function_midpoint = LOGISTIC_FUNCTION_MIDPOINT
+    self.logistic_function_growth = LOGISTIC_FUNCTION_GROWTH
+
+  def configure(self, config: ConfigParser):
+    failed_impact = config.getfloat("ScheduleEvaluation", "FailedImpact", fallback=None)
+    if failed_impact is not None:
+      logging.info(f"ScheduleEvaluator set schedule failed impact to {failed_impact}")
+      self.schedule_failed_impact = failed_impact
+
+    length_impact = config.getfloat("ScheduleEvaluation", "LengthImpact", fallback=None)
+    if length_impact is not None:
+      logging.info(f"ScheduleEvaluator set schedule length impact to {length_impact}")
+      self.schedule_length_impact = length_impact
     
+    logistic_function_midpoint = config.getfloat("ScheduleEvaluation", "LogisticFunctionMidpoint", fallback=None)
+    if logistic_function_midpoint is not None:
+      logging.info(f"ScheduleEvaluator set logistic function midpoint to {logistic_function_midpoint}")
+      self.logistic_function_midpoint = logistic_function_midpoint
+
+    logistic_function_growth = config.getfloat("ScheduleEvaluation", "LogisticFunctionGrowth", fallback=None)
+    if logistic_function_growth is not None:
+      logging.info(f"ScheduleEvaluator set logistic function growth to {logistic_function_growth}")
+      self.logistic_function_growth = logistic_function_growth
+
+  def _get_initial_state_quality(self, country_name: str) -> float:
+    # Lazy build initial quality lookup and don't repeat for subsequent calculations
+    start_quality = self.initial_quality_lookup.get(country_name)
+    if not start_quality:
+      start_state = self.initial_state[country_name]
+      logging.debug(start_state)
+      start_quality = self.state_quality_fn(start_state)
+      self.initial_quality_lookup[country_name] = start_quality
+      logging.info(f"Calculated initial quality - {country_name} = {start_quality}")
+    
+    return start_quality
+  
+  def _get_current_state_quality(self, country_name: str, schedule: Schedule) -> float:
+    end_state = schedule.get_country_state(country_name)
+    return self.state_quality_fn(end_state)
 
   def undiscounted_reward(self, country: Country, schedule: Schedule):
     logging.debug(self.undiscounted_reward.__name__)
-    start_state = self.initial_state[country.name]
-    logging.debug(start_state)
-    start_quality = self.state_quality_fn(start_state)
-    logging.debug(start_quality)
-    end_state = schedule.get_country_state(country.name)
-    logging.debug(end_state)
-    end_quality = self.state_quality_fn(end_state) 
-    logging.debug(end_quality)
-    return end_quality - start_quality
+
+    start_quality = self._get_initial_state_quality(country.name)
+    logging.debug(f"Start Quality {start_quality}")
+
+    end_quality = self._get_current_state_quality(country.name, schedule)
+    logging.debug(f"End Quality {end_quality}")
+
+    undiscounted_reward = end_quality - start_quality
+    logging.debug(f"Undiscounted Reward = {undiscounted_reward}")  
+    
+    return undiscounted_reward
 
   def discounted_reward(self, country: Country, schedule: Schedule) -> float:
     logging.debug(self.discounted_reward.__name__)
-    gamma = SCHEDULE_LENGTH_IMPACT
-    N = schedule.get_steps()
-    R = self.undiscounted_reward
-    return float(gamma * N * R(country, schedule))
+    
+    undiscounted_reward = self.undiscounted_reward(country, schedule)
+    discount = self.schedule_length_impact ** schedule.get_steps()
+    discounted_reward = float(undiscounted_reward * discount)
+    logging.debug(f"Discounted Reward = {discounted_reward}")
 
-  def logistic_success(self, country: Country, schedule: Schedule) -> float:
-    logging.debug(self.logistic_success.__name__)
-    c = country
-    s = schedule
-    DR = self.discounted_reward
-    x = DR(c, s)
-    logging.debug("Discounted Reward = {}".format(str(x)))
-    L = 1
-    x_0 = 1
-    k = 1
+    return discounted_reward
+
+  def logistic_function(self, x: float) -> float:
+    '''See https://en.wikipedia.org/wiki/Logistic_function'''
+
+    # Supremum (Least Upper Bound) of a probability (0-1) would be 1
+    L = 1 
+
+    # Midpoint of the function on the x-axis
+    # shifting negative makes success more likely
+    # shifting positive makes success less likely
+    # zero is neutral, where if x (discounted reward) is also 0, success is 50/50
+    x_0 = self.logistic_function_midpoint
+
+    # Function's exponential growth or steepness
+    # Negative values invert the curve, interpreting negative DR as success (bad)
+    # Increasing the (positive) value increases the impact changes in DR have on probability 
+    k = self.logistic_function_growth
 
     try:
       exponent =  ( -k * ( x - x_0 ) )
-      power = math.pow(math.e, exponent)
+      power = math.e ** exponent
     except OverflowError:
       power = float("inf")
 
     return float( L / ( 1 + power ) )
+
+  def logistic_success(self, country: Country, schedule: Schedule) -> float:
+    logging.debug(self.logistic_success.__name__)
+
+    if country.name == self.self_country_name:
+      return 1
+    
+    discounted_reward = self.discounted_reward(country, schedule)
+    return self.logistic_function(discounted_reward)
 
   def country_schedule_success_probability(self, country: Country, schedule: Schedule) -> float:
     return self.logistic_success(country, schedule)
@@ -65,12 +129,38 @@ class ScheduleEvaluator:
     for country in countries:
       prob = prob * self.country_schedule_success_probability(country, schedule)
     return prob
+  
+  def log_country_probabilities(self, schedule: Schedule):
+    logging.debug(self.log_country_probabilities.__name__)
+    countries = schedule.get_impacted_countries()
+
+    for country in countries:
+      prob = self.country_schedule_success_probability(country, schedule)
+      logging.info(f"Country Schedule Success - {country.name} {(prob*100):.2f}%")
+
+  def log_country_states_diff(self, schedule: Schedule):
+    logging.debug(self.log_country_states_diff.__name__)
+    countries = schedule.get_impacted_countries()
+
+    for country in countries:
+      start_state = self.initial_state.get(country.name)
+      final_state = schedule.node.STATE.get(country.name)
+      diff = Country.diff_resource_quantities(start_state, final_state)
+      undiscounted_reward = self.undiscounted_reward(country, schedule)
+      logging.info(f"Country State Diff - {country.name} {diff}")
+      logging.info(f"Country State Quality Change - {country.name} {undiscounted_reward}")
 
   def expected_utility(self, country: Country, schedule: Schedule) -> float:
     logging.debug(self.expected_utility.__name__)
-    P = self.schedule_success_probability
-    DR = self.discounted_reward
-    c = country
-    s = schedule
-    C = SCHEDULE_FAILED_IMPACT
-    return float((P(s) * DR(c, s)) + ((1-P(s)) * C))
+    
+    discounted_reward = self.discounted_reward(country, schedule)
+    success_probability = self.schedule_success_probability(schedule)
+    failure_probability = 1-success_probability
+
+    logging.debug(f"EU Success Probability {success_probability}")
+    logging.debug(f"EU Failure Probability {failure_probability}")
+
+    expected_utility = float((success_probability * discounted_reward) + (failure_probability * self.schedule_failed_impact))
+    logging.debug(f"Expected Utility = {expected_utility}")
+
+    return expected_utility

--- a/WorldTraderSim/src/WorldTraderSim/config.ini
+++ b/WorldTraderSim/src/WorldTraderSim/config.ini
@@ -9,3 +9,13 @@ Strategy=HeuristicDepthFirstSearch
 ; Strategy=BestFirstSearch
 EnableReached=True
 ; EnableReached=False
+
+[ScheduleEvaluation]
+# Penalty multiplied by schedule failure probability (C)
+FailedImpact=-0.35
+# Exponentially decreases the expected utility of a schedule over time (gamma)
+LengthImpact=0.999
+# Changes the likelihood a schedule will be successful, zero is neutral (x_0)
+LogisticFunctionMidpoint=-1
+# Changes how significantly a delta in discounted reward moves success probability (k)
+LogisticFunctionGrowth=1

--- a/WorldTraderSim/src/WorldTraderSim/graph_schedule.py
+++ b/WorldTraderSim/src/WorldTraderSim/graph_schedule.py
@@ -52,7 +52,7 @@ def parseCmdLineArgs():
   return parser.parse_args()
 
 def main(): 
-  logging.info("Starting WorldTraderSim")
+  logging.info("Graphing WorldTraderSim best schedule...")
   args = parseCmdLineArgs ()
   logging.getLogger().setLevel(args.logging_level)
 


### PR DESCRIPTION
Prior to this PR, the schedule length impact (gamma) value was being applied as a constant within the discounted reward calculation. As a result, with each step (depth) in the search, the EU value would, generally, increase substantially. With the change in the calculation, agent behavior can now swing wildly with how depth is weighted, so be cautious in changing the default values.

Changes:
* Store STATE_HASH as a value on the Node and return if populated rather than re-hashing
* Store DEPTH as a value on the Node and return if populated rather than counting again
* Fix ScheduleEvaluator schedule length impact (gamma) calculation to properly apply steps as an exponent
* Update ScheduleEvaluator to allow configuration of calculation variables
* Update ScheduleEvaluator to add new logging functions to be used for final output comparisons
* Update config.ini and main.py to take advantage of ScheduleEvaluator changes